### PR TITLE
Look for and display days and times for multi-day events

### DIFF
--- a/_events/template.md
+++ b/_events/template.md
@@ -3,6 +3,13 @@ published: false # Remove this line for real events.
 title: "Fun Hackathon"
 description: "A short summary shown on home page and elsewhere"
 date: 2000-01-01 11:30am
+days: # This field is optional but good to set for multi-day events.
+  - day:2000-01-01
+    start: 11:30am
+    end: 8:00pm
+  - day: 2000-01-02 # Add as many days as needed.
+    start: 12:00pm
+    end: 6:00pm 
 address: "45 W 18th St, New York, NY 10011"
 rsvp: "http://eventbrite.link.or.similar"
 image: "place-this-image-file-in-assets-slash-events.jpg"

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -15,7 +15,11 @@ layout: default
     <h2>{{page.description}}</h2>
   {% endif %}
 
-  {% if page.date %}
+  {% if page.days %}
+    {% for day in page.days %}
+        <h3>{{day.day | date: site.date_format }} {{day.start | date: site.time_format}} - {{day.end | date: site.time_format}}</h3>
+    {% endfor %}
+  {% elsif page.date %}
     <h3>{{page.date | date: site.date_format }}</h3>
     <h3>{{page.date | date: site.time_format }}</h3>
   {% endif %}


### PR DESCRIPTION
Some events cover multiple days and we want to show the start and end
times for each day of the event. With this change, the event layout
will look to see if the 'days' field is set on the event and display
that or fallback on the 'date' field.