### PR TITLE
Add space to fix build error with template.md

### DIFF
--- a/_events/template.md
+++ b/_events/template.md
@@ -4,7 +4,7 @@ title: "Fun Hackathon"
 description: "A short summary shown on home page and elsewhere"
 date: 2000-01-01 11:30am
 days: # This field is optional but good to set for multi-day events.
-  - day:2000-01-01
+  - day: 2000-01-01
     start: 11:30am
     end: 8:00pm
   - day: 2000-01-02 # Add as many days as needed.


### PR DESCRIPTION
Because of a missing space, when building or serving the site locally
for development work, an error would be displayed. This commit adds
that missing space.