### PR TITLE
Add Last Event to the home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,14 +6,12 @@ layout: default
 
   {{ content }}
 
-  <h1>Next event</h1>  
-  <ul class="post-list">
-    {% assign nextEvent = ((site.events | where_exp:"event", "event.date >= site.time") | sort: 'date' | limit: 1  %}
-    {% for event in nextEvent %}
-      <li>
-        {% include event_list_item.html event=event %}
-      </li>
-    {% endfor %}
-  </ul>
+  <h1>Next event</h1> 
+  {% assign nextEvents = ((site.events | where_exp:"event", "event.date >= site.time") | sort: 'date' %}
+  {% include event_list_item.html event=nextEvents.first %}
+
+  <h1>Last event</h1>
+  {% assign pastEvents = ((site.events | where_exp:"event", "event.date <= site.time") | sort: 'date' | reverse %}
+  {% include event_list_item.html event=pastEvents.first %}
 
 </div>


### PR DESCRIPTION
This commit adds the most recent past event to the home page.
It also cleans up the code for showing the Next Event to be
more succinct.