### PR TITLE
Add 'next event' to the footer

### DIFF
--- a/_includes/event_list_item.html
+++ b/_includes/event_list_item.html
@@ -1,7 +1,9 @@
-<span class="post-meta">{{ include.event.date | date: site.date_format }}</span>
-<h2>
-	<a class="post-link" href="{{ include.event.url | relative_url }}">{{ include.event.title | escape }}</a>
-</h2>
-{% if include.event.description %}
-	<p class="post-meta">{{ include.event.description }}</p>
+{% if include.event %}
+  <span class="post-meta">{{ include.event.date | date: site.date_format }}</span>
+  <h2><a class="post-link" href="{{ include.event.url | relative_url }}">{{ include.event.title | escape }}</a></h2>
+  {% if include.event.description %}
+  	<p class="post-meta">{{ include.event.description }}</p>
+  {% endif %}
+{% else %}
+  <h2>Check back soon.</h2>
 {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,18 +6,14 @@
 
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
-        <ul class="contact-list">
-          <li>
-            {% if site.author %}
-              {{ site.author | escape }}
-            {% else %}
-              {{ site.title | escape }}
-            {% endif %}
-            </li>
-            {% if site.email %}
-            <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-            {% endif %}
-        </ul>
+        {% assign upcomingEvents = ((site.events | where_exp:"event", "event.date >= site.time") | sort: 'date' %}
+        {% assign nextEvent = upcomingEvents.first %}
+        <p>Next Event:</p>
+        {% if nextEvent %}
+          <p><a href="{{ nextEvent.url | relative_url }}">{{ nextEvent.title | escape }}</a></p>
+        {% else %}
+          <p>Check back soon.</p>
+        {% endif %}
       </div>
 
       <div class="footer-col footer-col-2">
@@ -51,7 +47,10 @@
             {% include icon-empty.html url=site.facebook_url text="Facebook" %}
           </li>
           {% endif %}
-
+          {% if site.email %}
+            {% assign email_url = "mailto:" | append: site.email) %}
+            {% include icon-empty.html url=email_url text="Email us" %}
+          {% endif %}
         </ul>
       </div>
 


### PR DESCRIPTION
This commit adds a link to the next event in the footer
of the website, moving the email contact information to
the bottom of the list of social links. This was something
we decided to do in the website meeting.