### PR TITLE
deleted z-index, added float

### DIFF
--- a/_sass/mmh/_header.scss
+++ b/_sass/mmh/_header.scss
@@ -146,8 +146,8 @@
     right: -20px;
     top: -36px;
     display: inline-block;
-    width: 100%;
-    z-index: -1;
+    width: 375px;
+    float: right;
 
       .page-link {
         color: $text-color;


### PR DESCRIPTION
- Got rid of negative z-index on site-nav class in largest-width media query, as I forgot that z-index was not just a cosmetic change but actually made the menu links inaccessible at 800px+ screen width.  Instead, shortened width to fixed pixel length instead of 100%, and floated the whole section right.