### PR TITLE
Update MusED Hackathon content

### DIFF
--- a/_events/2017-08-05.md
+++ b/_events/2017-08-05.md
@@ -22,10 +22,43 @@ Stay tuned to our blog, twitter, or facebook for more announcements!
 
 # Talks
 
-Announced soon...
+- Michela Ledwidge
+- Sarah Farzam
+- Shay Ase, Diandre Miller, Jamel Mims
+- Kate Stone
+- Adam Goldberg
+
+The [talks](https://impactconference2017.sched.com/event/Bfrc/opening-short-talks) were moderated by Alex Ruthmann.
 
 # Workshops
 
-Announced soon...
+- [**Connecting Music, Technology and Every Day Experience**](https://impactconference2017.sched.com/event/BcpZ/authentic-connections-connecting-music-technology-and-everyday-experience-using-makey-makey-and-scratch)
+    - [Karioki Crosby](http://portraitofacreative.com/karioki_crosby/) *Artist, Curator, Museum Educator*
+    - [Liam Baum](https://twitter.com/mrbombmusic)  *Music Director, BELL Academy*
+
+
+- [**Global Passport: Teaching Young Children to Embrace Diversity Using Music**](https://impactconference2017.sched.com/event/BdZj/global-passport-teaching-young-children-to-embrace-diversity-using-music)
+    - [Sarah Farzam](http://www.bilingualbirdies.com/teachers/sarah-farzam/) *Bilingual Birdies*
+
+
+- [**The Living Remix Project, Sonic Portraits, Sample Universe! Oh my!**](https://impactconference2017.sched.com/event/BDED/the-living-remix-project-sonic-portraits-sample-universe-oh-my)
+  - [Aaron Lazansky-Olivas](http://sohnup.com/) *SpazeCraft One*
+
+
+- [**Experience on-demand: touring immersive shows**](https://impactconference2017.sched.com/event/Bfra/interactive-vr-for-music)
+    - [Michela Ledwidge](https://modprods.com/blog/siggraph-and-beyond/) *Mod*
+
+
+- [**Puzzlegram: Collaborative Music Making with Conductive Ink**](https://impactconference2017.sched.com/event/B09f/puzzlegram-collaborative-music-making)
+    - [Kate Stone](https://www.ted.com/speakers/kate_stone) *founder, Novalia*
+    - [Sunny Choi](https://impactconference2017.sched.com/speaker/ssc526) *PhD Candidate, NYU Music Education*
+
+
+- [**Connecting from the Periphery: Using Peripheral Devices to connect with iOS and Mac OS for Accessible Music Making**](https://impactconference2017.sched.com/event/B09u/connecting-from-the-periphery-using-peripheral-devices-to-connect-with-ios-and-mac-os-for-accessible-music-making)
+    - [Adam Goldberg](https://impactconference2017.sched.com/speaker/4logicaledu) *P.S. 177*
+
+
+- [**Soft-circuit Musical Interface Workshop**](https://impactconference2017.sched.com/event/BDEI/soft-circuit-musical-interface-workshop)
+    - [Antonious Wiriadjaja](http://antoni.us/) *Interactive Media Arts, NYU Shanghai*
 
 Artwork by [Diana Castro](http://panali.cc/)


### PR DESCRIPTION
This is the content!

Note - a lot of the links go to the impact site. Should we check that the Impact site is going to remain up, or make backups of descriptions? Or pull the info (such as workshop descriptions) into our event description?

My vote's for linking to the site, and somehow checking periodically to see that [external](https://github.com/endymion/link-checker) and [internal](http://digitaldrummerj.me/jekyll-validating-links-and-images/) links (throughout the blog, not just for this event) aren't dead, and if links are dead, just removing them.